### PR TITLE
resetting whitespace so it is not inherited from above

### DIFF
--- a/src/canopy-react-error-boundary.js
+++ b/src/canopy-react-error-boundary.js
@@ -33,7 +33,7 @@ export default function decorateOptions(opts) {
           return null;
         } else {
           return (
-            <div className="cps-modal" id="canopy-react-error-boundary-modal">
+            <div className="cps-modal" id="canopy-react-error-boundary-modal" style={{whiteSpace: "normal"}}>
               <div className="cps-modal__screen" />
               <div className="cps-modal__dialog cps-card__height-3" style={{maxWidth: '100vw', transform: "translateX(-50%)", left: "50%"}}>
                 <div className="cps-card__header cps-subheader-sm">


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/3054066/74460598-59d68980-4e4a-11ea-9ec5-57a76f7979c9.png)

if a parent of canopy-react-error-boundary sets whitespace to nowrap, then this looks bad.